### PR TITLE
Move rstudio_download_url to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 # defaults file
 ---
 rstudio_version: '2023.03.1-446'
+rstudio_download_url: "https://download1.rstudio.org/electron/bionic/{{ rstudio_machine_map[ansible_machine] }}/rstudio-{{ rstudio_version }}-{{ rstudio_machine_map[ansible_machine] }}.deb"
 rstudio_install: []

--- a/vars/_default.yml
+++ b/vars/_default.yml
@@ -1,3 +1,2 @@
 # vars file
 ---
-rstudio_download_url: "https://download1.rstudio.org/electron/bionic/{{ rstudio_machine_map[ansible_machine] }}/rstudio-{{ rstudio_version }}-{{ rstudio_machine_map[ansible_machine] }}.deb"

--- a/vars/_stretch.yml
+++ b/vars/_stretch.yml
@@ -1,3 +1,2 @@
 # vars file
 ---
-rstudio_download_url: "https://download1.rstudio.org/electron/debian9/{{ ansible_machine }}/rstudio-{{ rstudio_version }}-{{ rstudio_machine_map[ansible_machine] }}.deb"


### PR DESCRIPTION
When fetching the latest rstudio version `rstudio_version: '2023.12.1-402'` the url set via `rstudio_download_url` from vars is not correct anymore.

Moving the  `rstudio_download_url` var to defaults whould be great